### PR TITLE
chore: move project to its own org and update the name on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 > An API for my public data
 
-[![codecov](https://codecov.io/gh/chrisvogt/js-personal-api/branch/master/graph/badge.svg)](https://codecov.io/gh/chrisvogt/js-personal-api) [![Build Status](https://travis-ci.org/chrisvogt/js-personal-api.svg?branch=master)](https://travis-ci.org/chrisvogt/js-personal-api) [![Join the chat at https://gitter.im/chrisvogt/js-personal-api](https://badges.gitter.im/chrisvogt/js-personal-api.svg)](https://gitter.im/chrisvogt/js-personal-api?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fchrisvogt%2Fjs-personal-api.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fchrisvogt%2Fjs-personal-api?ref=badge_shield) 
+[![codecov](https://codecov.io/gh/personal-api/core/branch/master/graph/badge.svg)](https://codecov.io/gh/personal-api/core) [![Build Status](https://travis-ci.org/personal-api/core.svg?branch=master)](https://travis-ci.org/personal-api/core) [![Join the chat at https://gitter.im/personal-api/core](https://badges.gitter.im/personal-api/core.svg)](https://gitter.im/personal-api/core?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fpersonal-api%2Fcore.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fpersonal-api%2Fcore?ref=badge_shield) 
 
 
-JS Personal API is an opinionated Node.js and Express app that serves as an interface to my public data collected from various online sources. The goal is to replace [the static data](https://chrisvogt.firebaseio.com/v1.json) I'm currently using for [my website](https://www.chrisvogt.me) with calls to this API.
+JS Personal API is an opinionated Node.js and Express app that serves as an interface to my public data on various online networks and providers. The goal is to replace [the static data](https://chrisvogt.firebaseio.com/v1.json) I'm currently using for [my website](https://www.chrisvogt.me) with calls to this API.
 
 _This project is new and unstable. Use at your discretion._
 
@@ -72,4 +72,4 @@ The `npm` commands available are:
 | `test` | runs the unit tests |
 
 ## License
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fchrisvogt%2Fjs-personal-api.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fchrisvogt%2Fjs-personal-api?ref=badge_large)
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fpersonal-api%2Fcore.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fpersonal-api%2Fcore?ref=badge_large)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "js-personal-api",
   "version": "0.1.0",
   "description": "API for managing personal data across various networks and providers.",
-  "homepage": "https://github.com/chrisvogt/js-personal-api#readme",
+  "homepage": "https://github.com/personal-api/core#readme",
   "author": {
     "name": "Chris Vogt",
     "email": "mail@chrisvogt.me",
@@ -23,7 +23,7 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/chrisvogt/js-personal-api/issues"
+    "url": "https://github.com/personal-api/core/issues"
   },
   "repository": {},
   "dependencies": {


### PR DESCRIPTION
The PR moves the repository to https://github.com/personal-api/core. I plan to release plugins in the same org.