### PR TITLE
feat: add quotes route

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -4,6 +4,7 @@ export default {
     METAS: 'metas',
     PROFILES: 'profiles',
     PROJECTS: 'projects',
+    QUOTES: 'quotes',
     REPOSITORIES: 'repositories',
   },
   DEFAULT_CACHE_TIME: '3 hours',

--- a/src/controllers/composite.js
+++ b/src/controllers/composite.js
@@ -6,6 +6,7 @@ const {
   METAS,
   PROFILES,
   PROJECTS,
+  QUOTES,
   REPOSITORIES,
 } = constants.COLLECTIONS;
 
@@ -14,12 +15,14 @@ const getComposite = async (req, res) => {
     const metas = await getAllDocuments(METAS);
     const profiles = await getAllDocuments(PROFILES);
     const projects = await getAllDocuments(PROJECTS);
+    const quotes = await getAllDocuments(QUOTES);
     const repositories = await getAllDocuments(REPOSITORIES);
 
     sendSuccess(res, {
       metas,
       profiles,
       projects,
+      quotes,
       repositories,
     });
   } catch (error) {

--- a/src/controllers/quotes.js
+++ b/src/controllers/quotes.js
@@ -1,0 +1,16 @@
+import constants from '../constants';
+import { getAllDocuments } from '../database/services';
+import { sendError, sendSuccess } from '../api/base';
+
+const { QUOTES } = constants.COLLECTIONS;
+
+const getQuotes = async (req, res) => {
+  try {
+    const quotes = await getAllDocuments(QUOTES);
+    sendSuccess(res, { quotes });
+  } catch (error) {
+    sendError(res, { error });
+  }
+};
+
+export default getQuotes;

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,6 +5,7 @@ import getComposite from './controllers/composite';
 import getMetas from './controllers/metas';
 import getProfiles from './controllers/profiles';
 import getProjects from './controllers/projects';
+import getQuotes from './controllers/quotes';
 import getRepositories from './controllers/repositories';
 
 const isProduction = process.env.NODE_ENV === 'production';
@@ -20,5 +21,6 @@ export default (app) => {
   app.use('/metas', cache(DEFAULT_CACHE_TIME), getMetas);
   app.use('/profiles', cache(DEFAULT_CACHE_TIME), getProfiles);
   app.use('/projects', cache(DEFAULT_CACHE_TIME), getProjects);
+  app.use('/quotes', cache(DEFAULT_CACHE_TIME), getQuotes);
   app.use('/repositories', cache(DEFAULT_CACHE_TIME), getRepositories);
 };

--- a/test/_fixtures/quote.js
+++ b/test/_fixtures/quote.js
@@ -1,0 +1,6 @@
+const quoteFixture = {
+  text: 'Man is born free and everywhere he is in chains.',
+  cite: 'Jean-Jacques Rousseau',
+};
+
+export default quoteFixture;

--- a/test/controllers/composite.js
+++ b/test/controllers/composite.js
@@ -8,6 +8,7 @@ const {
   METAS,
   PROFILES,
   PROJECTS,
+  QUOTES,
   REPOSITORIES,
 } = constants.COLLECTIONS;
 
@@ -41,6 +42,7 @@ describe('composite controller', () => {
       stubGetAllDocuments.withArgs(METAS).resolves(METAS);
       stubGetAllDocuments.withArgs(PROFILES).resolves(PROFILES);
       stubGetAllDocuments.withArgs(PROJECTS).resolves(PROJECTS);
+      stubGetAllDocuments.withArgs(QUOTES).resolves(QUOTES);
       stubGetAllDocuments.withArgs(REPOSITORIES).resolves(REPOSITORIES);
     });
 
@@ -50,6 +52,7 @@ describe('composite controller', () => {
         [METAS],
         [PROFILES],
         [PROJECTS],
+        [QUOTES],
         [REPOSITORIES],
       ]);
     });
@@ -60,6 +63,7 @@ describe('composite controller', () => {
         [METAS]: METAS,
         [PROFILES]: PROFILES,
         [PROJECTS]: PROJECTS,
+        [QUOTES]: QUOTES,
         [REPOSITORIES]: REPOSITORIES,
       }]]);
     });

--- a/test/controllers/quotes.js
+++ b/test/controllers/quotes.js
@@ -3,7 +3,6 @@ import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
 import quoteFixture from '../_fixtures/quote';
-// import getQuotes from '../../src/controllers/quotes';
 
 const sandbox = sinon.createSandbox();
 const stubGetAllDocuments = sandbox.stub().resolves([quoteFixture]);

--- a/test/controllers/quotes.js
+++ b/test/controllers/quotes.js
@@ -1,0 +1,68 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+import quoteFixture from '../_fixtures/quote';
+// import getQuotes from '../../src/controllers/quotes';
+
+const sandbox = sinon.createSandbox();
+const stubGetAllDocuments = sandbox.stub().resolves([quoteFixture]);
+const stubSendError = sandbox.stub();
+const stubSendSuccess = sandbox.stub();
+
+const getQuotes = proxyquire
+  .noCallThru()
+  .load('../../src/controllers/quotes.js', {
+    '../api/base': {
+      sendError: stubSendError,
+      sendSuccess: stubSendSuccess,
+    },
+    '../database/services': {
+      getAllDocuments: stubGetAllDocuments,
+    },
+  }).default;
+
+describe('quotes controller', () => {
+  const req = { query: {} };
+  const res = sandbox.stub();
+
+  afterEach(() => {
+    sandbox.resetHistory();
+  });
+
+  describe('getQuotes', () => {
+    describe('default response', () => {
+      const quotesArr = [quoteFixture, quoteFixture];
+
+      beforeEach(async () => {
+        stubGetAllDocuments.resolves(quotesArr);
+        await getQuotes(req, res);
+      });
+
+      it('queries the quotes collection', () => {
+        expect(stubGetAllDocuments.args).to.deep.equal([['quotes']]);
+      });
+
+      it('returns the quotes', () => {
+        expect(stubSendSuccess.args).to.deep.equal([[res, {
+          quotes: quotesArr,
+        }]]);
+      });
+    });
+
+    describe('error handling', () => {
+      const mockError = new Error('something went wrong');
+
+      beforeEach(async () => {
+        stubGetAllDocuments.rejects(mockError);
+        await getQuotes(req, res);
+      });
+
+      it('returns the error', () => {
+        expect(stubSendError.args).to.deep.equal([[res, {
+          error: mockError,
+        }]]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a route to return the quotes data currently served from a static GitHub Gist.

### Manual test

Response generated by a curl request to local web server.

```
< HTTP/1.1 200 OK
< X-Powered-By: Express
< Access-Control-Allow-Origin: *
< Content-Type: application/json; charset=utf-8
< Content-Length: 159
< ETag: W/"9f-tOTgp4hJOl8Eb4IehrJ4N0EiBaA"
< Date: Wed, 29 Aug 2018 02:36:05 GMT
< Connection: keep-alive
<
{ [159 bytes data]
* Connection #0 to host api.dev-chrisvogt.me left intact
{"status":"ok","result":{"quotes":[{"body":"It has been my philosophy of life that difficulties vanish when faced boldly","cite":"Isaac Asimov, Foundation"}]}}
```