### PR TITLE
feat: parse timestamps in projects

### DIFF
--- a/src/controllers/composite.js
+++ b/src/controllers/composite.js
@@ -1,5 +1,6 @@
 import constants from '../constants';
 import { getAllDocuments } from '../database/services';
+import { parseProject } from './projects';
 import { sendError, sendSuccess } from '../api/base';
 
 const {
@@ -21,7 +22,7 @@ const getComposite = async (req, res) => {
     sendSuccess(res, {
       metas,
       profiles,
-      projects,
+      projects: projects.map(parseProject),
       quotes,
       repositories,
     });

--- a/src/models/project.js
+++ b/src/models/project.js
@@ -1,4 +1,10 @@
+import get from 'lodash/get';
+
 const getProject = project => project;
+
+export const getCreated = project => get(project, 'created._seconds');
+export const getSynced = project => get(project, 'synced._seconds');
+export const getUpdated = project => get(project, 'updated._seconds');
 
 export const getName = project => project.name;
 

--- a/src/mutators/convertTimestampToMs.js
+++ b/src/mutators/convertTimestampToMs.js
@@ -1,0 +1,1 @@
+export default seconds => seconds * 1000;

--- a/test/controllers/composite.js
+++ b/test/controllers/composite.js
@@ -14,6 +14,7 @@ const {
 
 const sandbox = sinon.createSandbox();
 const stubGetAllDocuments = sandbox.stub();
+const stubParseProject = project => project;
 const stubSendError = sandbox.stub();
 const stubSendSuccess = sandbox.stub();
 
@@ -23,6 +24,9 @@ const getComposite = proxyquire
     '../api/base': {
       sendError: stubSendError,
       sendSuccess: stubSendSuccess,
+    },
+    './projects': {
+      parseProject: stubParseProject,
     },
     '../database/services': {
       getAllDocuments: stubGetAllDocuments,
@@ -38,10 +42,12 @@ describe('composite controller', () => {
   });
 
   describe('getComposite()', () => {
+    const mockProjects = [{ id: '1' }, { id: '2' }];
+
     before(() => {
       stubGetAllDocuments.withArgs(METAS).resolves(METAS);
       stubGetAllDocuments.withArgs(PROFILES).resolves(PROFILES);
-      stubGetAllDocuments.withArgs(PROJECTS).resolves(PROJECTS);
+      stubGetAllDocuments.withArgs(PROJECTS).resolves(mockProjects);
       stubGetAllDocuments.withArgs(QUOTES).resolves(QUOTES);
       stubGetAllDocuments.withArgs(REPOSITORIES).resolves(REPOSITORIES);
     });
@@ -62,7 +68,7 @@ describe('composite controller', () => {
       expect(stubSendSuccess.args).to.deep.equal([[res, {
         [METAS]: METAS,
         [PROFILES]: PROFILES,
-        [PROJECTS]: PROJECTS,
+        [PROJECTS]: mockProjects,
         [QUOTES]: QUOTES,
         [REPOSITORIES]: REPOSITORIES,
       }]]);

--- a/test/mutators/convertTimestampToMs.js
+++ b/test/mutators/convertTimestampToMs.js
@@ -1,0 +1,15 @@
+import { expect } from 'chai';
+import convertTimestampToMs from '../../src/mutators/convertTimestampToMs';
+
+describe('convertTimestampToSeconds mutator', () => {
+  it('converts a second to a millisecond', () => {
+    expect(convertTimestampToMs(1)).to.equal(1000);
+  });
+
+  it('converts epoch timestamps from seconds to milliseconds', () => {
+    const epochTimestampInMs = 1538288268000;
+    const epochTimestampInSeconds = 1538288268;
+    const result = convertTimestampToMs(epochTimestampInSeconds);
+    expect(result).to.equal(epochTimestampInMs);
+  });
+});


### PR DESCRIPTION
This PR manually converts the Firestore Timestamp (seconds) into Epoch time / ms.

### Screenshots

###### `/projects` endpoint

<img width="1054" alt="screen shot 2018-09-29 at 11 33 55 pm" src="https://user-images.githubusercontent.com/1934719/46254208-78e49f00-c440-11e8-8826-cf4f9a23841f.png">

###### `/composite` endpoint